### PR TITLE
Fix tag format in build-image workflow

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -37,4 +37,4 @@ jobs:
           context: .
           file: ./Dockerfile
           build-args: TOFU_VERSION=${{ github.event.inputs.version }}
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ github.event.inputs.version }}
+          tags: ${{ env.IMAGE }}:${{ github.event.inputs.version }}


### PR DESCRIPTION
Remove the registry prefix from the image tags in the build-image workflow.