### PR TITLE
Add push option to build-image workflow

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -36,5 +36,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          push: true
           build-args: TOFU_VERSION=${{ github.event.inputs.version }}
           tags: ${{ env.IMAGE }}:${{ github.event.inputs.version }}


### PR DESCRIPTION
Include a push option in the build and push step of the build-image workflow to enable automatic image pushing after building.