### PR TITLE
Update image name in build-image workflow

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE: ${{ github.repository }}
+  IMAGE: labbs/opentofu-container-image
 
 jobs:
   build:
@@ -38,4 +38,4 @@ jobs:
           file: ./Dockerfile
           push: true
           build-args: TOFU_VERSION=${{ github.event.inputs.version }}
-          tags: ${{ env.IMAGE }}:${{ github.event.inputs.version }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ github.event.inputs.version }}


### PR DESCRIPTION
Change the image name in the build-image workflow to use a fixed repository path for consistency and clarity.